### PR TITLE
add corrected  `libconfig.c` and `wincompat.h`

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -115,7 +115,7 @@ static void __config_locale_override(void)
 
 #else
 
-#warning "No way to modify calling thread's locale!"
+#pragma warning "No way to modify calling thread's locale!"
 
 #endif
 }
@@ -135,7 +135,7 @@ static void __config_locale_restore(void)
 
 #else
 
-#warning "No way to modify calling thread's locale!"
+#pragma warning "No way to modify calling thread's locale!"
 
 #endif
 }

--- a/lib/wincompat.h
+++ b/lib/wincompat.h
@@ -31,7 +31,7 @@
 
 #define LIBCONFIG_WINDOWS_OS
 
-if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__MINGW32__) || defined(__MINGW64__)
 #define LIBCONFIG_MINGW_OS
 #endif
 
@@ -120,7 +120,7 @@ extern int posix_fsync(int fd);
 
 #else /* defined(LIBCONFIG_WINDOWS_OS) && !defined(LIBCONFIG_MINGW_OS) */
 
-#include <unistd.h> /* for fsync() */
+//#include <unistd.h> /* for fsync() */
 
 #define posix_fileno fileno
 #define posix_fsync  fsync
@@ -132,6 +132,9 @@ extern int posix_fsync(int fd);
 #define IS_RELATIVE_PATH(P) \
   ((P)[0] != '/')
 
+
 #endif /* defined(LIBCONFIG_WINDOWS_OS) && !defined(LIBCONFIG_MINGW_OS) */
+
+#endif /* defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(WIN64) || defined(_WIN64) || defined(__WIN64__) */
 
 #endif /* __wincompat_h */


### PR DESCRIPTION
### Changes in `libconfig.c`:

* Replaced `#warning` with `#pragma warning` for better compatibility across compilers in `__config_locale_override` and `__config_locale_restore`. [[1]](diffhunk://#diff-6e9a9e5c7e55f9be0bd3e59a88d1995d38a52ed10246fce026daf2a36cf71071L118-R118) [[2]](diffhunk://#diff-6e9a9e5c7e55f9be0bd3e59a88d1995d38a52ed10246fce026daf2a36cf71071L138-R138)

### Changes in `wincompat.h`:

* Fixed a missing `#` in the `#if` directive for checking MinGW environments.
* Commented out the inclusion of `<unistd.h>` under certain conditions to avoid unnecessary dependencies.
* Added a missing newline and an additional `#endif` for better code structure and clarity.